### PR TITLE
Replace /bin/true with true

### DIFF
--- a/test/sharness.t
+++ b/test/sharness.t
@@ -446,7 +446,7 @@ test_expect_success 'empty sharness.d directory does not cause failure' '
 		test_description="sharness works"
 		. ./sharness.sh
 		test_expect_success "test success" "
-			/bin/true
+			true
 		"
 		test_done
 		EOF


### PR DESCRIPTION
The test 'empty sharness.d directory does not cause failure' fails on *BSD because it uses /bin/true.  *BSD places this executable in /usr/bin/true.

Replace /bin/true with true to use the shell builtin or find the executable via PATH.