### PR TITLE
Fix long test of 'EXPENSIVE prereq not activated by default'

### DIFF
--- a/test/sharness.t
+++ b/test/sharness.t
@@ -372,6 +372,7 @@ test_expect_success COLOR,PERL_AND_TTY 'sub-sharness still has color' "
 "
 
 test_expect_success 'EXPENSIVE prereq not activated by default' "
+	unset TEST_LONG &&
 	run_sub_test_lib_test no-long 'long test' <<-\\EOF &&
 	test_expect_success 'passing test' 'true'
 	test_expect_success EXPENSIVE 'passing suposedly long test' 'true'


### PR DESCRIPTION
Test 23 (EXPENSIVE prereq not activated by default) fails when `sharness.t` is run with the `--long-tests` option.  When this option is specified, the TEST_LONG environment variable is set and passed on to the sub_test. This causes the EXPENSIVE prereq to be met, which causes sub_test 2 to not be skipped, which causes the overall test to fail:
```
$ ./sharness.t -l
ok 1 - sourcing sharness succeeds
ok 2 - success is reported like this
not ok 3 - pretend we have a known breakage # TODO known breakage
ok 4 - pretend we have a fully passing test suite
ok 5 - pretend we have a partially passing test suite
ok 6 - pretend we have a known breakage
ok 7 - pretend we have fixed a known breakage
ok 8 - pretend we have fixed one of two known breakages (run in sub sharness)
ok 9 - pretend we have a pass, fail, and known breakage
ok 10 - pretend we have a mix of all possible results
ok 11 - test runs if prerequisite is satisfied
ok 12 # skip unmet prerequisite causes test to be skipped (missing DONTHAVEIT)
ok 13 - test runs if prerequisites are satisfied
ok 14 # skip unmet prerequisites causes test to be skipped (missing DONTHAVEIT of HAVEIT,DONTHAVEIT)
ok 15 # skip unmet prerequisites causes test to be skipped (missing DONTHAVEIT of DONTHAVEIT,HAVEIT)
ok 16 - tests clean up after themselves
ok 17 - tests clean up even on failures
ok 18 - cleanup functions run at the end of the test
ok 19 - We detect broken && chains
ok 20 - tests can be run from an alternate directory
ok 21 - SHARNESS_ORIG_TERM propagated to sub-sharness
ok 22 - sub-sharness still has color
not ok 23 - EXPENSIVE prereq not activated by default
#       
#               run_sub_test_lib_test no-long 'long test' <<-\EOF &&
#               test_expect_success 'passing test' 'true'
#               test_expect_success EXPENSIVE 'passing suposedly long test' 'true'
#               test_done
#               EOF
#               check_sub_test_lib_test no-long <<-\EOF
#               > ok 1 - passing test
#               > ok 2 # skip passing suposedly long test (missing EXPENSIVE)
#               > # passed all 2 test(s)
#               > 1..2
#               EOF
#       
ok 24 - EXPENSIVE prereq is activated by --long
ok 25 - loading sharness extensions works
ok 26 - empty sharness.d directory does not cause failure
ok 27 # skip Interactive tests work (missing INTERACTIVE)
# still have 1 known breakage(s)
# failed 1 among remaining 26 test(s)
1..27
```

Unset TEST_LONG from the environment to prevent passing this setting to the sub_test.