### PR TITLE
Fix four typos. Regenerate API.md with "make doc."

### DIFF
--- a/API.md
+++ b/API.md
@@ -1,349 +1,349 @@
 # Sharness API
 
-### SHARNESS_VERSION
+`SHARNESS_VERSION`
+------------------
 
-    Public: Current version of Sharness.
+Public: Current version of Sharness.
 
-### SHARNESS_TEST_EXTENSION
 
-    Public: The file extension for tests.  By default, it is set to "t".
+`SHARNESS_TEST_EXTENSION`
+-------------------------
 
-### SHARNESS_ORIG_TERM
+Public: The file extension for tests.  By default, it is set to "t".
 
-    Public: The unsanitized TERM under which sharness is originally run
 
-### test_set_prereq()
+`SHARNESS_ORIG_TERM`
+--------------------
 
-    Public: Define that a test prerequisite is available.
+Public: The unsanitized TERM under which sharness is originally run
 
-    The prerequisite can later be checked explicitly using test_have_prereq or
-    implicitly by specifying the prerequisite name in calls to test_expect_success
-    or test_expect_failure.
 
-    $1 - Name of prerequiste (a simple word, in all capital letters by convention)
+`test_set_prereq()`
+-------------------
 
-    Examples
+Public: Define that a test prerequisite is available.
 
-      # Set PYTHON prerequisite if interpreter is available.
-      command -v python >/dev/null && test_set_prereq PYTHON
+The prerequisite can later be checked explicitly using test_have_prereq or implicitly by specifying the prerequisite name in calls to test_expect_success or test_expect_failure.
 
-      # Set prerequisite depending on some variable.
-      test -z "$NO_GETTEXT" && test_set_prereq GETTEXT
+* $1 - Name of prerequisite (a simple word, in all capital letters by convention)
 
-    Returns nothing.
+Examples
 
-### test_have_prereq()
+    # Set PYTHON prerequisite if interpreter is available.
+    command -v python >/dev/null && test_set_prereq PYTHON
 
-    Public: Check if one or more test prerequisites are defined.
+    # Set prerequisite depending on some variable.
+    test -z "$NO_GETTEXT" && test_set_prereq GETTEXT
 
-    The prerequisites must have previously been set with test_set_prereq.
-    The most common use of this is to skip all the tests if some essential
-    prerequisite is missing.
+Returns nothing.
 
-    $1 - Comma-separated list of test prerequisites.
 
-    Examples
+`test_have_prereq()`
+--------------------
 
-      # Skip all remaining tests if prerequisite is not set.
-      if ! test_have_prereq PERL; then
-          skip_all='skipping perl interface tests, perl not available'
-          test_done
-      fi
+Public: Check if one or more test prerequisites are defined.
 
-    Returns 0 if all prerequisites are defined or 1 otherwise.
+The prerequisites must have previously been set with test_set_prereq. The most common use of this is to skip all the tests if some essential prerequisite is missing.
 
-### test_debug()
+* $1 - Comma-separated list of test prerequisites.
 
-    Public: Execute commands in debug mode.
+Examples
 
-    Takes a single argument and evaluates it only when the test script is started
-    with --debug. This is primarily meant for use during the development of test
-    scripts.
+    # Skip all remaining tests if prerequisite is not set.
+    if ! test_have_prereq PERL; then
+        skip_all='skipping perl interface tests, perl not available'
+        test_done
+    fi
 
-    $1 - Commands to be executed.
+Returns 0 if all prerequisites are defined or 1 otherwise.
 
-    Examples
 
-      test_debug "cat some_log_file"
+`test_debug()`
+--------------
 
-    Returns the exit code of the last command executed in debug mode or 0
-      otherwise.
+Public: Execute commands in debug mode.
 
-### test_pause()
+Takes a single argument and evaluates it only when the test script is started with --debug. This is primarily meant for use during the development of test scripts.
 
-    Public: Stop execution and start a shell.
+* $1 - Commands to be executed.
 
-    This is useful for debugging tests and only makes sense together with "-v".
-    Be sure to remove all invocations of this command before submitting.
+Examples
 
-### test_expect_success()
+    test_debug "cat some_log_file"
 
-    Public: Run test commands and expect them to succeed.
+Returns the exit code of the last command executed in debug mode or 0    otherwise.
 
-    When the test passed, an "ok" message is printed and the number of successful
-    tests is incremented. When it failed, a "not ok" message is printed and the
-    number of failed tests is incremented.
 
-    With --immediate, exit test immediately upon the first failed test.
+`test_pause()`
+--------------
 
-    Usually takes two arguments:
-    $1 - Test description
-    $2 - Commands to be executed.
+Public: Stop execution and start a shell.
 
-    With three arguments, the first will be taken to be a prerequisite:
-    $1 - Comma-separated list of test prerequisites. The test will be skipped if
-         not all of the given prerequisites are set. To negate a prerequisite,
-         put a "!" in front of it.
-    $2 - Test description
-    $3 - Commands to be executed.
+This is useful for debugging tests and only makes sense together with "-v". Be sure to remove all invocations of this command before submitting.
 
-    Examples
 
-      test_expect_success \
-          'git-write-tree should be able to write an empty tree.' \
-          'tree=$(git-write-tree)'
+`test_expect_success()`
+-----------------------
 
-      # Test depending on one prerequisite.
-      test_expect_success TTY 'git --paginate rev-list uses a pager' \
-          ' ... '
+Public: Run test commands and expect them to succeed.
 
-      # Multiple prerequisites are separated by a comma.
-      test_expect_success PERL,PYTHON 'yo dawg' \
-          ' test $(perl -E 'print eval "1 +" . qx[python -c "print 2"]') == "4" '
+When the test passed, an "ok" message is printed and the number of successful tests is incremented. When it failed, a "not ok" message is printed and the number of failed tests is incremented.
 
-    Returns nothing.
+With --immediate, exit test immediately upon the first failed test.
 
-### test_expect_failure()
+Usually takes two arguments:
+* $1 - Test description
+* $2 - Commands to be executed.
 
-    Public: Run test commands and expect them to fail. Used to demonstrate a known
-    breakage.
+With three arguments, the first will be taken to be a prerequisite:
+* $1 - Comma-separated list of test prerequisites. The test will be skipped if not all of the given prerequisites are set. To negate a prerequisite, put a "!" in front of it.
+* $2 - Test description
+* $3 - Commands to be executed.
 
-    This is NOT the opposite of test_expect_success, but rather used to mark a
-    test that demonstrates a known breakage.
+Examples
 
-    When the test passed, an "ok" message is printed and the number of fixed tests
-    is incremented. When it failed, a "not ok" message is printed and the number
-    of tests still broken is incremented.
+    test_expect_success \
+        'git-write-tree should be able to write an empty tree.' \
+        'tree=$(git-write-tree)'
 
-    Failures from these tests won't cause --immediate to stop.
+    # Test depending on one prerequisite.
+    test_expect_success TTY 'git --paginate rev-list uses a pager' \
+        ' ... '
 
-    Usually takes two arguments:
-    $1 - Test description
-    $2 - Commands to be executed.
+    # Multiple prerequisites are separated by a comma.
+    test_expect_success PERL,PYTHON 'yo dawg' \
+        ' test $(perl -E 'print eval "1 +" . qx[python -c "print 2"]') == "4" '
 
-    With three arguments, the first will be taken to be a prerequisite:
-    $1 - Comma-separated list of test prerequisites. The test will be skipped if
-         not all of the given prerequisites are set. To negate a prerequisite,
-         put a "!" in front of it.
-    $2 - Test description
-    $3 - Commands to be executed.
+Returns nothing.
 
-    Returns nothing.
 
-### test_must_fail()
+`test_expect_failure()`
+-----------------------
 
-    Public: Run command and ensure that it fails in a controlled way.
+Public: Run test commands and expect them to fail. Used to demonstrate a known breakage.
 
-    Use it instead of "! <command>". For example, when <command> dies due to a
-    segfault, test_must_fail diagnoses it as an error, while "! <command>" would
-    mistakenly be treated as just another expected failure.
+This is NOT the opposite of test_expect_success, but rather used to mark a test that demonstrates a known breakage.
 
-    This is one of the prefix functions to be used inside test_expect_success or
-    test_expect_failure.
+When the test passed, an "ok" message is printed and the number of fixed tests is incremented. When it failed, a "not ok" message is printed and the number of tests still broken is incremented.
 
-    $1.. - Command to be executed.
+Failures from these tests won't cause --immediate to stop.
 
-    Examples
+Usually takes two arguments:
+* $1 - Test description
+* $2 - Commands to be executed.
 
-      test_expect_success 'complain and die' '
-          do something &&
-          do something else &&
-          test_must_fail git checkout ../outerspace
-      '
+With three arguments, the first will be taken to be a prerequisite:
+* $1 - Comma-separated list of test prerequisites. The test will be skipped if not all of the given prerequisites are set. To negate a prerequisite, put a "!" in front of it.
+* $2 - Test description
+* $3 - Commands to be executed.
 
-    Returns 1 if the command succeeded (exit code 0).
-    Returns 1 if the command died by signal (exit codes 130-192)
-    Returns 1 if the command could not be found (exit code 127).
-    Returns 0 otherwise.
+Returns nothing.
 
-### test_might_fail()
 
-    Public: Run command and ensure that it succeeds or fails in a controlled way.
+`test_must_fail()`
+------------------
 
-    Similar to test_must_fail, but tolerates success too. Use it instead of
-    "<command> || :" to catch failures caused by a segfault, for instance.
+Public: Run command and ensure that it fails in a controlled way.
 
-    This is one of the prefix functions to be used inside test_expect_success or
-    test_expect_failure.
+Use it instead of "! <command>". For example, when <command> dies due to a segfault, test_must_fail diagnoses it as an error, while "! <command>" would mistakenly be treated as just another expected failure.
 
-    $1.. - Command to be executed.
+This is one of the prefix functions to be used inside test_expect_success or test_expect_failure.
 
-    Examples
+* $1.. - Command to be executed.
 
-      test_expect_success 'some command works without configuration' '
-          test_might_fail git config --unset all.configuration &&
-          do something
-      '
+Examples
 
-    Returns 1 if the command died by signal (exit codes 130-192)
-    Returns 1 if the command could not be found (exit code 127).
-    Returns 0 otherwise.
+    test_expect_success 'complain and die' '
+        do something &&
+        do something else &&
+        test_must_fail git checkout ../outerspace
+    '
 
-### test_expect_code()
+Returns 1 if the command succeeded (exit code 0). Returns 1 if the command died by signal (exit codes 130-192) Returns 1 if the command could not be found (exit code 127). Returns 0 otherwise.
 
-    Public: Run command and ensure it exits with a given exit code.
 
-    This is one of the prefix functions to be used inside test_expect_success or
-    test_expect_failure.
+`test_might_fail()`
+-------------------
 
-    $1   - Expected exit code.
-    $2.. - Command to be executed.
+Public: Run command and ensure that it succeeds or fails in a controlled way.
 
-    Examples
+Similar to test_must_fail, but tolerates success too. Use it instead of "<command> || :" to catch failures caused by a segfault, for instance.
 
-      test_expect_success 'Merge with d/f conflicts' '
-          test_expect_code 1 git merge "merge msg" B master
-      '
+This is one of the prefix functions to be used inside test_expect_success or test_expect_failure.
 
-    Returns 0 if the expected exit code is returned or 1 otherwise.
+* $1.. - Command to be executed.
 
-### test_cmp()
+Examples
 
-    Public: Compare two files to see if expected output matches actual output.
+    test_expect_success 'some command works without configuration' '
+        test_might_fail git config --unset all.configuration &&
+        do something
+    '
 
-    The TEST_CMP variable defines the command used for the comparision; it
-    defaults to "diff -u". Only when the test script was started with --verbose,
-    will the command's output, the diff, be printed to the standard output.
+Returns 1 if the command died by signal (exit codes 130-192) Returns 1 if the command could not be found (exit code 127). Returns 0 otherwise.
 
-    This is one of the prefix functions to be used inside test_expect_success or
-    test_expect_failure.
 
-    $1 - Path to file with expected output.
-    $2 - Path to file with actual output.
+`test_expect_code()`
+--------------------
 
-    Examples
+Public: Run command and ensure it exits with a given exit code.
 
-      test_expect_success 'foo works' '
-          echo expected >expected &&
-          foo >actual &&
-          test_cmp expected actual
-      '
+This is one of the prefix functions to be used inside test_expect_success or test_expect_failure.
 
-    Returns the exit code of the command set by TEST_CMP.
+* $1   - Expected exit code.
+* $2.. - Command to be executed.
 
-### test_seq()
+Examples
 
-    Public: portably print a sequence of numbers.
+    test_expect_success 'Merge with d/f conflicts' '
+        test_expect_code 1 git merge "merge msg" B master
+    '
 
-    seq is not in POSIX and GNU seq might not be available everywhere,
-    so it is nice to have a seq implementation, even a very simple one.
+Returns 0 if the expected exit code is returned or 1 otherwise.
 
-    $1 - Starting number.
-    $2 - Ending number.
 
-    Examples
+`test_cmp()`
+------------
 
-      test_expect_success 'foo works 10 times' '
-          for i in $(test_seq 1 10)
-          do
-              foo || return
-          done
-      '
+Public: Compare two files to see if expected output matches actual output.
 
-    Returns 0 if all the specified numbers can be displayed.
+The TEST_CMP variable defines the command used for the comparison; it defaults to "diff -u". Only when the test script was started with --verbose, will the command's output, the diff, be printed to the standard output.
 
-### test_must_be_empty()
+This is one of the prefix functions to be used inside test_expect_success or test_expect_failure.
 
-    Public: Check if the file expected to be empty is indeed empty, and barfs
-    otherwise.
+* $1 - Path to file with expected output.
+* $2 - Path to file with actual output.
 
-    $1 - File to check for emptyness.
+Examples
 
-    Returns 0 if file is empty, 1 otherwise.
+    test_expect_success 'foo works' '
+        echo expected >expected &&
+        foo >actual &&
+        test_cmp expected actual
+    '
 
-### test_when_finished()
+Returns the exit code of the command set by TEST_CMP.
 
-    Public: Schedule cleanup commands to be run unconditionally at the end of a
-    test.
 
-    If some cleanup command fails, the test will not pass. With --immediate, no
-    cleanup is done to help diagnose what went wrong.
+`test_seq()`
+------------
 
-    This is one of the prefix functions to be used inside test_expect_success or
-    test_expect_failure.
+Public: portably print a sequence of numbers.
 
-    $1.. - Commands to prepend to the list of cleanup commands.
+seq is not in POSIX and GNU seq might not be available everywhere, so it is nice to have a seq implementation, even a very simple one.
 
-    Examples
+* $1 - Starting number.
+* $2 - Ending number.
 
-      test_expect_success 'test core.capslock' '
-          git config core.capslock true &&
-          test_when_finished "git config --unset core.capslock" &&
-          do_something
-      '
+Examples
 
-    Returns the exit code of the last cleanup command executed.
+    test_expect_success 'foo works 10 times' '
+        for i in $(test_seq 1 10)
+        do
+            foo || return
+        done
+    '
 
-### final_cleanup
+Returns 0 if all the specified numbers can be displayed.
 
-    Public: Schedule cleanup commands to be run unconditionally when all tests
-    have run.
 
-    This can be used to clean up things like test databases. It is not needed to
-    clean up temporary files, as test_done already does that.
+`test_must_be_empty()`
+----------------------
 
-    Examples:
+Public: Check if the file expected to be empty is indeed empty, and barfs otherwise.
 
-      cleanup mysql -e "DROP DATABASE mytest"
+* $1 - File to check for emptiness.
 
-    Returns the exit code of the last cleanup command executed.
+Returns 0 if file is empty, 1 otherwise.
 
-### test_done()
 
-    Public: Summarize test results and exit with an appropriate error code.
+`test_when_finished()`
+----------------------
 
-    Must be called at the end of each test script.
+Public: Schedule cleanup commands to be run unconditionally at the end of a test.
 
-    Can also be used to stop tests early and skip all remaining tests. For this,
-    set skip_all to a string explaining why the tests were skipped before calling
-    test_done.
+If some cleanup command fails, the test will not pass. With --immediate, no cleanup is done to help diagnose what went wrong.
 
-    Examples
+This is one of the prefix functions to be used inside test_expect_success or test_expect_failure.
 
-      # Each test script must call test_done at the end.
-      test_done
+* $1.. - Commands to prepend to the list of cleanup commands.
 
-      # Skip all remaining tests if prerequisite is not set.
-      if ! test_have_prereq PERL; then
-          skip_all='skipping perl interface tests, perl not available'
-          test_done
-      fi
+Examples
 
-    Returns 0 if all tests passed or 1 if there was a failure.
+    test_expect_success 'test core.capslock' '
+        git config core.capslock true &&
+        test_when_finished "git config --unset core.capslock" &&
+        do_something
+    '
 
-### SHARNESS_TEST_DIRECTORY
+Returns the exit code of the last cleanup command executed.
 
-    Public: Root directory containing tests. Tests can override this variable,
-    e.g. for testing Sharness itself.
 
-### SHARNESS_TEST_SRCDIR
+`final_cleanup`
+---------------
 
-    Public: Source directory of test code and sharness library.
-    This directory may be different from the directory in which tests are
-    being run.
+Public: Schedule cleanup commands to be run unconditionally when all tests have run.
 
-### SHARNESS_BUILD_DIRECTORY
+This can be used to clean up things like test databases. It is not needed to clean up temporary files, as test_done already does that.
 
-    Public: Build directory that will be added to PATH. By default, it is set to
-    the parent directory of SHARNESS_TEST_DIRECTORY.
+Examples:
 
-### SHARNESS_TEST_FILE
+    cleanup mysql -e "DROP DATABASE mytest"
 
-    Public: Path to test script currently executed.
+Returns the exit code of the last cleanup command executed.
 
-### SHARNESS_TRASH_DIRECTORY
 
-    Public: Empty trash directory, the test area, provided for each test. The HOME
-    variable is set to that directory too.
+`test_done()`
+-------------
 
-Generated by tomdoc.sh version 0.1.5
+Public: Summarize test results and exit with an appropriate error code.
+
+Must be called at the end of each test script.
+
+Can also be used to stop tests early and skip all remaining tests. For this, set skip_all to a string explaining why the tests were skipped before calling test_done.
+
+Examples
+
+    # Each test script must call test_done at the end.
+    test_done
+
+    # Skip all remaining tests if prerequisite is not set.
+    if ! test_have_prereq PERL; then
+        skip_all='skipping perl interface tests, perl not available'
+        test_done
+    fi
+
+Returns 0 if all tests passed or 1 if there was a failure.
+
+
+`SHARNESS_TEST_DIRECTORY`
+-------------------------
+
+Public: Root directory containing tests. Tests can override this variable, e.g. for testing Sharness itself.
+
+
+`SHARNESS_TEST_SRCDIR`
+----------------------
+
+Public: Source directory of test code and sharness library. This directory may be different from the directory in which tests are being run.
+
+
+`SHARNESS_BUILD_DIRECTORY`
+--------------------------
+
+Public: Build directory that will be added to PATH. By default, it is set to the parent directory of SHARNESS_TEST_DIRECTORY.
+
+
+`SHARNESS_TEST_FILE`
+--------------------
+
+Public: Path to test script currently executed.
+
+
+`SHARNESS_TRASH_DIRECTORY`
+--------------------------
+
+Public: Empty trash directory, the test area, provided for each test. The HOME variable is set to that directory too.
+
+
+Generated by tomdoc.sh version 0.1.8

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,7 @@ That's why we would like you to follow the following guidelines:
   frown upon, and the style we prefer.
 
 - If some similar changes can benefit Git, it is a good idea to first
-  send patchs to the
+  send patches to the
   [Git mailing list](http://vger.kernel.org/vger-lists.html#git).
   Please follow the
   [Git documentation](https://github.com/git/git/blob/master/Documentation/SubmittingPatches)
@@ -44,7 +44,7 @@ That's why we would like you to follow the following guidelines:
 
 - API.md should be updated using `make doc` when new public functions
   or variables are added. They should be documented in
-  [TomDoc](https://github.com/mlafeldt/tomdoc.sh).
+  [TomDoc](https://github.com/tests-always-included/tomdoc.sh).
 
 Resources that might be helpful:
 

--- a/sharness.sh
+++ b/sharness.sh
@@ -177,7 +177,7 @@ trap 'die' EXIT
 # implicitly by specifying the prerequisite name in calls to test_expect_success
 # or test_expect_failure.
 #
-# $1 - Name of prerequiste (a simple word, in all capital letters by convention)
+# $1 - Name of prerequisite (a simple word, in all capital letters by convention)
 #
 # Examples
 #
@@ -570,7 +570,7 @@ test_expect_code() {
 
 # Public: Compare two files to see if expected output matches actual output.
 #
-# The TEST_CMP variable defines the command used for the comparision; it
+# The TEST_CMP variable defines the command used for the comparison; it
 # defaults to "diff -u". Only when the test script was started with --verbose,
 # will the command's output, the diff, be printed to the standard output.
 #
@@ -624,7 +624,7 @@ test_seq() {
 # Public: Check if the file expected to be empty is indeed empty, and barfs
 # otherwise.
 #
-# $1 - File to check for emptyness.
+# $1 - File to check for emptiness.
 #
 # Returns 0 if file is empty, 1 otherwise.
 test_must_be_empty() {


### PR DESCRIPTION
Updates to tomdoc.sh (now at version 0.1.8) trigger a lot of changes in API.md.

Also, CONTRIBUTING.md now points to TomDoc's current home. (N.B., Even
the last version at its old home triggers a comparable number of API.md
changes.)