### PR TITLE
sharness: replace shebang with title

### DIFF
--- a/sharness.sh
+++ b/sharness.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+# Sharness test framework.
 #
 # Copyright (c) 2011-2012 Mathias Lafeldt
 # Copyright (c) 2005-2012 Git project


### PR DESCRIPTION
In https://github.com/chriscool/sharness/issues/72 @sumpfralle suggests removing the shebang from `sharness.sh` as it is supposed to be sourced, not executed directly.

I think that indeed it could avoid mistakes and make it easier for packagers.