### PR TITLE
sharness.sh: remove useless LF definition

### DIFF
--- a/sharness.sh
+++ b/sharness.sh
@@ -75,10 +75,6 @@ EDITOR=:
 export LANG LC_ALL PAGER TZ EDITOR
 unset VISUAL CDPATH GREP_OPTIONS
 
-# Line feed
-LF='
-'
-
 [ "x$TERM" != "xdumb" ] && (
 		[ -t 1 ] &&
 		tput bold >/dev/null 2>&1 &&


### PR DESCRIPTION
LF appears to not being used anymore so let's remove it.

Thanks @sumpfralle for finding that as part of https://github.com/chriscool/sharness/pull/82 !

 