### PR TITLE
sharness: add option -x from Git's test-lib

### DIFF
--- a/sharness.sh
+++ b/sharness.sh
@@ -401,7 +401,9 @@ test_run_() {
 		fi
 	fi
 
-	if test -z "$immediate" || test $eval_ret = 0 || test -n "$expecting_failure"; then
+	if test -z "$immediate" || test $eval_ret = 0 ||
+	   test -n "$expecting_failure" && test "$test_cleanup" != ":"
+	then
 		test_eval_ "$test_cleanup"
 	fi
 	if test "$verbose" = "t" && test -n "$HARNESS_ACTIVE"; then

--- a/sharness.sh
+++ b/sharness.sh
@@ -395,10 +395,17 @@ test_run_() {
 	eval_ret=$?
 
 	if test "$chain_lint" = "t"; then
+		# turn off tracing for this test-eval, as it simply creates
+		# confusing noise in the "-x" output
+		trace_tmp=$trace
+		trace=
+		# 117 is magic because it is unlikely to match the exit
+		# code of other programs
 		test_eval_ "(exit 117) && $1"
 		if test "$?" != 117; then
 			error "bug in the test script: broken &&-chain: $1"
 		fi
+		trace=$trace_tmp
 	fi
 
 	if test -z "$immediate" || test $eval_ret = 0 ||

--- a/test/sharness.t
+++ b/test/sharness.t
@@ -276,6 +276,43 @@ test_expect_success 'pretend we have a pass, fail, and known breakage using --ve
 	test_cmp expect.sorted actual.sorted
 "
 
+test_expect_success 'pretend we have a pass, fail, and known breakage using -x' "
+	test_must_fail run_sub_test_lib_test \
+		mixed-results4 'mixed results #4' '' -x <<-\\EOF &&
+	test_expect_success 'passing test' 'true'
+	test_expect_success 'failing test' 'false'
+	test_expect_failure 'pretend we have a known breakage' 'false'
+	test_done
+	EOF
+	(
+		cd mixed-results4 &&
+		sed -e 's/^> //' -e 's/Z$//' >expect_out <<-\\EOF &&
+		> expecting success: true
+		> ok 1 - passing test
+		> 
+		> expecting success: false
+		> not ok 2 - failing test
+		> #	false
+		> 
+		> checking known breakage: false
+		> not ok 3 - pretend we have a known breakage # TODO known breakage
+		> 
+		> # still have 1 known breakage(s)
+		> # failed 1 among remaining 2 test(s)
+		> 1..3
+		EOF
+		test_cmp expect_out out &&
+		sed -e 's/^> //' -e 's/Z$//' >expect_err <<-\\EOF &&
+		> + true
+		> + false
+		> error: last command exited with \$?=1
+		> + false
+		> error: last command exited with \$?=1
+		EOF
+		test_cmp expect_err err
+	)
+"
+
 test_expect_success 'pretend we have some unstable tests' "
 	run_sub_test_lib_test \
 		results3 'results #3' <<-\\EOF &&

--- a/test/sharness.t
+++ b/test/sharness.t
@@ -292,7 +292,7 @@ test_expect_success 'pretend we have a pass, fail, and known breakage using -x' 
 	EOF
 	(
 		cd mixed-results4 &&
-		sed -e 's/^> //' -e 's/Z$//' >expect_out <<-\\EOF &&
+		sed -e 's/^> //' >expect_out <<-\\EOF &&
 		> expecting success: true
 		> ok 1 - passing test
 		> expecting success: false


### PR DESCRIPTION
This option can help a lot in debugging tests, as it shows
the last shell command that was executed.

It's especially useful along with -i and -v.