### PR TITLE
Set proper default shell

### DIFF
--- a/sharness.sh
+++ b/sharness.sh
@@ -51,7 +51,7 @@ export SHARNESS_TEST_SRCDIR
 export SHARNESS_ORIG_TERM
 
 # Export SHELL_PATH
-: "${SHELL_PATH:=$SHELL}"
+: "${SHELL_PATH:=/bin/sh}"
 export SHELL_PATH
 
 # if --tee was passed, write the output not only to the terminal, but


### PR DESCRIPTION
The Git project has always used POSIX shell format for a reason.

The code should run in the least common denominator shell; not the
currently running shell.