### PR TITLE
test: sharness: add support for output directory

### DIFF
--- a/lib-sharness/functions.sh
+++ b/lib-sharness/functions.sh
@@ -540,7 +540,7 @@ test_done() {
 	EXIT_OK=t
 
 	if test -z "$HARNESS_ACTIVE"; then
-		test_results_dir="$SHARNESS_TEST_DIRECTORY/test-results"
+		test_results_dir="$SHARNESS_TEST_OUTDIR/test-results"
 		mkdir -p "$test_results_dir"
 		test_results_path="$test_results_dir/$this_test.$$.counts"
 

--- a/sharness.sh
+++ b/sharness.sh
@@ -43,6 +43,17 @@ export SHARNESS_TEST_DIRECTORY
 # being run.
 export SHARNESS_TEST_SRCDIR
 
+if test -z "$SHARNESS_TEST_OUTDIR"
+then
+	# Similarly, override this to store the test-results subdir
+	# elsewhere
+	SHARNESS_TEST_OUTDIR=$SHARNESS_TEST_DIRECTORY
+fi
+
+# Public: Directory where the output of the tests should be stored (i.e.
+# trash directories).
+export SHARNESS_TEST_OUTDIR
+
 #  Reset TERM to original terminal if found, otherwise save original TERM
 [ "x" = "x$SHARNESS_ORIG_TERM" ] &&
 		SHARNESS_ORIG_TERM="$TERM" ||
@@ -61,8 +72,8 @@ done,*)
 	# do not redirect again
 	;;
 *' --tee '*|*' --verbose-log '*)
-	mkdir -p "$SHARNESS_TEST_DIRECTORY/test-results"
-	BASE="$SHARNESS_TEST_DIRECTORY/test-results/$(basename "$0" ".$SHARNESS_TEST_EXTENSION")"
+	mkdir -p "$SHARNESS_TEST_OUTDIR/test-results"
+	BASE="$SHARNESS_TEST_OUTDIR/test-results/$(basename "$0" ".$SHARNESS_TEST_EXTENSION")"
 
 	# Make this filename available to the sub-process in case it is using
 	# --verbose-log.
@@ -349,7 +360,7 @@ SHARNESS_TRASH_DIRECTORY="trash directory.$(basename "$SHARNESS_TEST_FILE" ".$SH
 test -n "$root" && SHARNESS_TRASH_DIRECTORY="$root/$SHARNESS_TRASH_DIRECTORY"
 case "$SHARNESS_TRASH_DIRECTORY" in
 /*) ;; # absolute path is good
- *) SHARNESS_TRASH_DIRECTORY="$SHARNESS_TEST_DIRECTORY/$SHARNESS_TRASH_DIRECTORY" ;;
+ *) SHARNESS_TRASH_DIRECTORY="$SHARNESS_TEST_OUTDIR/$SHARNESS_TRASH_DIRECTORY" ;;
 esac
 test "$debug" = "t" || remove_trash="$SHARNESS_TRASH_DIRECTORY"
 rm -rf "$SHARNESS_TRASH_DIRECTORY" || {

--- a/test/sharness.t
+++ b/test/sharness.t
@@ -415,7 +415,7 @@ test_expect_success 'tests can be run from an alternate directory' '
 	EOF
         (
           # unset SHARNESS variables before sub-test
-	  unset SHARNESS_TEST_DIRECTORY SHARNESS_TEST_SRCDIR &&
+	  unset SHARNESS_TEST_DIRECTORY SHARNESS_TEST_OUTDIR SHARNESS_TEST_SRCDIR &&
 	  # unset HARNESS_ACTIVE so we get a test-results dir
 	  unset HARNESS_ACTIVE &&
 	  chmod +x test.t &&


### PR DESCRIPTION
I don't know why this was removed from Git's version.

It's incredibly useful to output everything to a temporary directory to
run the tests faster (if it's a memory mount).