### PR TITLE
test/sharness: normalize output more

### DIFF
--- a/test/sharness.t
+++ b/test/sharness.t
@@ -64,7 +64,8 @@ run_sub_test_lib_test () {
 		cat >>".$name.t" &&
 		chmod +x ".$name.t" &&
 		export SHARNESS_TEST_SRCDIR &&
-		$prefix ./".$name.t" $opt --chain-lint >out 2>err
+		# Setting PS4 simplifies properly testing set -x output
+		PS4=+ $prefix ./".$name.t" $opt --chain-lint >out 2>err
 	)
 }
 
@@ -279,9 +280,9 @@ test_expect_success 'pretend we have a pass, fail, and known breakage using --ve
 # Unfortunately it looks like set -x doesn't behave exactly the same
 # way everywhere. Sometimes in its output it adds blanklines or "+ "
 # before the commands that are run, and sometimes it doesn't add
-# blanklines and adds only one or more "+" before commands. This might
-# be related to how PS4 is set. Anyway let's try to clean up the output
-# to be able to compare properly.
+# blanklines and adds only one or more "+" before commands. This is
+# also influenced by PS4, which we set above. Let's anyway clean up
+# the output using sed to compare as properly as possible.
 
 test_expect_success 'pretend we have a pass, fail, and known breakage using -x' "
 	test_must_fail run_sub_test_lib_test \

--- a/test/sharness.t
+++ b/test/sharness.t
@@ -279,8 +279,9 @@ test_expect_success 'pretend we have a pass, fail, and known breakage using --ve
 # Unfortunately it looks like set -x doesn't behave exactly the same
 # way everywhere. Sometimes in its output it adds blanklines or "+ "
 # before the commands that are run, and sometimes it doesn't add
-# blanklines and adds only "+" before commands. So we need to clean up
-# the output to be able to compare properly.
+# blanklines and adds only one or more "+" before commands. This might
+# be related to how PS4 is set. Anyway let's try to clean up the output
+# to be able to compare properly.
 
 test_expect_success 'pretend we have a pass, fail, and known breakage using -x' "
 	test_must_fail run_sub_test_lib_test \
@@ -313,7 +314,7 @@ test_expect_success 'pretend we have a pass, fail, and known breakage using -x' 
 		> +false
 		> error: last command exited with \$?=1
 		EOF
-		sed -e 's/^+ /+/' >clean_err <err &&
+		sed -e 's/^++* */+/' >clean_err <err &&
 		test_cmp expect_err clean_err
 	)
 "


### PR DESCRIPTION
In 3e0777c (test/sharness: normalize -x output before testing
it, 2019-06-27), we tried to normalize -x output before we
would test it, but it looks like this is sometimes not enough.
So let's also normalize the '+' characters that -x can output.

Fixes: https://github.com/chriscool/sharness/issues/104