### PR TITLE
Run sharness test suite with github actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,21 @@
+name: Tests
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+        - windows-latest
+        - ubuntu-latest
+        - macos-latest
+    runs-on: ${{ matrix.os }}
+    steps:
+    - uses: actions/checkout@v2
+    - name: Run Tests
+      env:
+        TEST_OPTS: -v
+        MSYS: winsymlinks:nativestrict
+      run: make test


### PR DESCRIPTION
To minimize the opportunities for bugs and regressions, let's run
sharness test suite on every push and pull request.

Tests are ran on the latest versions of the operating systems currently
supported by github actions.