### PR TITLE
Revert "test/test-terminal.perl: Rename master-slave terms"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v2
+    - name: Install IO::Pty
+      if: matrix.os == 'ubuntu-latest'
+      run: sudo apt-get update -y && sudo apt-get install -y libio-pty-perl
     - name: Run Tests
       env:
         TEST_OPTS: -v

--- a/test/test-terminal.perl
+++ b/test/test-terminal.perl
@@ -67,14 +67,14 @@ sub copy_stdio {
 if ($#ARGV < 1) {
 	die "usage: test-terminal program args";
 }
-my $leader_out = new IO::Pty;
-my $leader_err = new IO::Pty;
-$leader_out->set_raw();
-$leader_err->set_raw();
-$leader_out->follower->set_raw();
-$leader_err->follower->set_raw();
-my $pid = start_child(\@ARGV, $leader_out->follower, $leader_err->follower);
-close $leader_out->follower;
-close $leader_err->follower;
-copy_stdio($leader_out, $leader_err);
+my $master_out = new IO::Pty;
+my $master_err = new IO::Pty;
+$master_out->set_raw();
+$master_err->set_raw();
+$master_out->slave->set_raw();
+$master_err->slave->set_raw();
+my $pid = start_child(\@ARGV, $master_out->slave, $master_err->slave);
+close $master_out->slave;
+close $master_err->slave;
+copy_stdio($master_out, $master_err);
 exit(finish_child($pid));


### PR DESCRIPTION
This reverts commit 06aadc33d9b31b0bcdfd1cef121c7effa9781dde.

It seems that IO::Pty does not have a 'follower' method. The
method is named 'slave'. So we cannot really get rid of the
master-slave terminology until there is an upstream update
or until we find another Perl module to replace IO::Pty.

Fixes: https://github.com/chriscool/sharness/issues/105