### PR TITLE
vim: indent: remove continuation-line

### DIFF
--- a/vim/indent/sharness.vim
+++ b/vim/indent/sharness.vim
@@ -1,0 +1,3 @@
+let b:sh_indent_options = { 'continuation-line': 0 }
+
+runtime! indent/sh.vim


### PR DESCRIPTION
So that the sh indentation doesn't try to indent the lines after the
first command:

	true &&
		test x == x &&
		echo success

Signed-off-by: Felipe Contreras <felipe.contreras@gmail.com>